### PR TITLE
Change name of the package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ copy_file(os.path.join(dir_path, 'sendgrid', 'VERSION.txt'),
           verbose=0)
 
 setup(
-    name='sendgrid',
+    name='sendgrid6',
     version=version,
     author='Elmer Thomas, Yamil Asusta',
     author_email='dx@sendgrid.com',


### PR DESCRIPTION
This is a temporary hack - fork off the latest release and change the name of the package.
This will basically allow us to install 2 different versions of the same package in a single environment (virtualenv)

**NOT TO BE MERGED**
It should be installed off the `iw` branch instead of master.